### PR TITLE
add requirements & renew description

### DIFF
--- a/docker_stats.py
+++ b/docker_stats.py
@@ -28,7 +28,7 @@ def normalize(dictionary):
 
 
 def main():
-    parser = argparse.ArgumentParser(description='docker stats, json way')
+    parser = argparse.ArgumentParser(description='Docker stats wrapper which prints output in json')
     parser.add_argument('containers', metavar='container', type=str, nargs='*', help='IDs or NAMEs of desired containers')
     parser.add_argument('-a', '--all', dest='all', action='store_true', help='get stats of all available containers')
     parser.add_argument('-n', '--normalize', dest='normalize', action='store_true', help='try to normalize stats')

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,23 @@ from setuptools import setup
 
 
 if __name__ == '__main__':
+
+    requirements = [
+        'docker-py <= 1.10.6',
+        'json'
+    ]
+
     setup(
         name='docker-stats',
-        version='0.0.2',
+        version='0.0.3',
 
         license='Apache License, Version 2.0',
         author="Marat Mavlyutov",
         author_email="mavlyutov@yandex-team.ru",
-        description='docker stats, json way',
+        description='Docker stats wrapper which prints output in json',
         long_description=open('README.rst').read(),
         url='https://github.com/mavlyutov/docker-stats',
+        install_requires=requirements,
 
         py_modules=['docker_stats'],
         entry_points={

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,7 @@ from setuptools import setup
 if __name__ == '__main__':
 
     requirements = [
-        'docker-py <= 1.10.6',
-        'json'
+        'docker-py <= 1.10.6'
     ]
 
     setup(


### PR DESCRIPTION
Add requirements and lock `docker-py` version  cause `docker-py>=2.0` has incompatible syntax with `<=1.10.6` which used here