### PR TITLE
Name feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@ Install from PyPI and run ::
           -h, --help  show this help message and exit
           -a, --all   get stats of all available containers
           -n, --normalize   try to normalize stats
+          -N, --names   return containers names instead of Ids with replacing non-digit and non-word symbols to underscores
 
 
 Normalization

--- a/docker_stats.py
+++ b/docker_stats.py
@@ -3,8 +3,7 @@
 import argparse
 import docker
 import json
-
-from operator import itemgetter
+import re
 
 
 def normalize(dictionary):
@@ -27,20 +26,32 @@ def normalize(dictionary):
     return dictionary
 
 
+def container_name(id):
+    """
+    Find container`s name by its ID and return it with replacing non-word and non-digit symbols to underscores
+    :param id: Container`s Id
+    :return: Container`s name
+    """
+
+    client = docker.Client(base_url='unix://var/run/docker.sock', version='auto')
+    return re.sub('[^\w]', '_', client.inspect_container['Name'])
+
+
 def main():
     parser = argparse.ArgumentParser(description='docker stats, json way')
     parser.add_argument('containers', metavar='container', type=str, nargs='*', help='IDs or NAMEs of desired containers')
     parser.add_argument('-a', '--all', dest='all', action='store_true', help='get stats of all available containers')
     parser.add_argument('-n', '--normalize', dest='normalize', action='store_true', help='try to normalize stats')
+    parser.add_argument('-N', '--names', dest='names', action='store_true', help='return containers names instead of Ids with replacing non-digit and non-word symbols to underscores')
     args = parser.parse_args()
 
     if not args.containers and not args.all:
         parser.print_usage()
         parser.exit()
 
-    client = docker.Client(base_url='unix://var/run/docker.sock')
-    ids = args.all and map(itemgetter('Id'), client.containers(quiet=True)) or args.containers
+    client = docker.Client(base_url='unix://var/run/docker.sock', version='auto')
+    ids = args.all and [container['Id'] for container in client.containers(quiet=True)] or args.containers
 
-    stats = {c: client.stats(c, stream=0) for c in ids}
+    stats = {args.names and container_name(c) or c: client.stats(c, stream=0) for c in ids}
     stats = args.normalize and normalize(stats) or stats
     print json.dumps(stats)

--- a/docker_stats.py
+++ b/docker_stats.py
@@ -34,7 +34,7 @@ def container_name(id):
     """
 
     client = docker.Client(base_url='unix://var/run/docker.sock', version='auto')
-    return re.sub('[^\w]', '_', client.inspect_container['Name'])
+    return re.sub('[^\w]', '_', re.sub('^/', '', client.inspect_container(id)['Name']))
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,14 @@ from setuptools import setup
 
 
 if __name__ == '__main__':
+
+    requirements = [
+        'docker-py <= 1.10.6'
+    ]
+
     setup(
         name='docker-stats',
-        version='0.0.2',
+        version='0.0.3',
 
         license='Apache License, Version 2.0',
         author="Marat Mavlyutov",
@@ -14,6 +19,7 @@ if __name__ == '__main__':
         description='docker stats, json way',
         long_description=open('README.rst').read(),
         url='https://github.com/mavlyutov/docker-stats',
+        install_requires=requirements,
 
         py_modules=['docker_stats'],
         entry_points={


### PR DESCRIPTION
Add key `-N (--names)` which allows to show names instead of Ids in tool results when using `-a (--all)` key

Before:

```sh
docker-stats -a -n
{
"873bed5be204605f21f3235910527a47": {"stats": ...},
"60d54ae654b6534873bed5be204605f21f3235": {"stats": ...},
...
}
```

After:

```sh
docker-stats -a -n -N
{"dark_moon": {"stats": ...},
"lovely_python": {"stats": ...},
...
}
```

Also add requirements to setup and auto selecting version of docker engine